### PR TITLE
Fix receiver get channel correctly

### DIFF
--- a/media/media.go
+++ b/media/media.go
@@ -55,7 +55,7 @@ func (m *Media) AddSender(channelID string, userID string, sdp string) (string, 
 
 // AddReceiver creates a new downstream connection and adds it to the channel.
 func (m *Media) AddReceiver(channelID string, userID string, sdp string) (string, error) {
-	ch := channel.New()
+	ch := m.channels[channelID]
 	conn, err := connection.NewOutbound(m.connectionConfig, sdp)
 	if err != nil {
 		return "", fmt.Errorf("failed to make connection: %w", err)
@@ -70,6 +70,5 @@ func (m *Media) AddReceiver(channelID string, userID string, sdp string) (string
 		return "", fmt.Errorf("failed to start ICE: %w", err)
 	}
 
-	m.channels[channelID] = ch
 	return conn.ServerSDP(), nil
 }


### PR DESCRIPTION
### Description

Currently, Receiver make their channel directly. I think this is mistake from making `AddReceiver` from `AddSender`. So now, Receiver finds channel by channel id correctly.


### Related Issues

### Changes Made

Receiver finds channel by channel id correctly.


### Checklist
- [x] Tests have been added/updated or not required
- [x] didn't break anything

### Additional Context
Add any other context or information that reviewers should know about here.

### Reviewer Notes
If there are specific areas you want feedback on, mention them here.

