### PR TITLE
Add Unit Tests for cmd Package Configuration Functions

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,226 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"pdn/cmd"
+	"pdn/signal"
+	"testing"
+)
+
+// ParseArgs parses the command-line arguments and returns the configuration.
+// It returns an error if the arguments are invalid.
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    signal.Config
+		wantErr bool
+	}{
+		{
+			name: "given valid args when parsed then return config",
+			args: []string{"-port=8080", "-key=/path/to/key.pem", "-cert=/path/to/cert.pem"},
+			want: signal.Config{Port: 8080, KeyFile: "/path/to/key.pem", CertFile: "/path/to/cert.pem"},
+		},
+		{
+			name: "given missing port when parsed then return config with default port",
+			args: []string{"-key=/path/to/key.pem", "-cert=/path/to/cert.pem"},
+			want: signal.Config{Port: signal.DefaultPort, KeyFile: "/path/to/key.pem", CertFile: "/path/to/cert.pem"},
+		},
+		{
+			name:    "given empty key file when parsed then return config with empty key file",
+			args:    []string{"-port=8080", "-cert=/path/to/cert.pem"},
+			want:    signal.Config{Port: 8080, KeyFile: "", CertFile: "/path/to/cert.pem"},
+			wantErr: false,
+		},
+		{
+			name:    "given empty cert file when parsed then return config with empty cert file",
+			args:    []string{"-port=8080", "-key=/path/to/key.pem"},
+			want:    signal.Config{Port: 8080, KeyFile: "/path/to/key.pem", CertFile: ""},
+			wantErr: false,
+		},
+		{
+			name: "given no args when parsed then return config",
+			args: []string{},
+			want: signal.Config{Port: signal.DefaultPort, KeyFile: "", CertFile: ""},
+		},
+		{
+			name:    "given extra args when parsed then return error",
+			args:    []string{"-port=8080", "-key=/path/to/key.pem", "-cert=/path/to/cert.pem", "extra"},
+			wantErr: true,
+		},
+		{
+			name:    "given invalid flag format when parsed then return error",
+			args:    []string{"-extra"},
+			wantErr: true,
+		},
+		{
+			name:    "given invalid non-flag args when parsed then return error",
+			args:    []string{"port"},
+			wantErr: true,
+		},
+		{
+			name:    "given port flag without value when parsed then return error",
+			args:    []string{"-port"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			got, err := cmd.ParseArgs(&output, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseArgs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !got.IsSame(tt.want) {
+				t.Errorf("ParseArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Helper function to create a temporary file and return its path
+func createTempFile() (string, error) {
+	tmpFile, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		return "", err
+	}
+	if closeErr := tmpFile.Close(); closeErr != nil {
+		return "", closeErr
+	}
+	return tmpFile.Name(), nil
+}
+
+// TestSetupConfig tests the SetupConfig function, including handling errors from ParseArgs and Config.Validate.
+func TestSetupConfig(t *testing.T) {
+	keyFile, err := createTempFile()
+	if err != nil {
+		t.Fatalf("Failed to create temporary key file: %v", err)
+	}
+	certFile, err := createTempFile()
+	if err != nil {
+		t.Fatalf("Failed to create temporary cert file: %v", err)
+	}
+
+	// Clean up temporary files after the test
+	defer func() {
+		_ = os.Remove(keyFile)
+		_ = os.Remove(certFile)
+	}()
+
+	tests := []struct {
+		name          string
+		args          []string
+		expected      signal.Config
+		parseError    bool
+		validateError bool
+	}{
+		{
+			name: "given valid args when setup config then return valid config",
+			args: []string{"-port=8080", "-key=" + keyFile, "-cert=" + certFile},
+			expected: signal.Config{
+				Port:     8080,
+				KeyFile:  keyFile,
+				CertFile: certFile,
+			},
+			parseError:    false,
+			validateError: false,
+		},
+		{
+			name: "given no args when setup config then return default config",
+			args: []string{},
+			expected: signal.Config{
+				Port:     signal.DefaultPort,
+				KeyFile:  "",
+				CertFile: "",
+			},
+			parseError:    false,
+			validateError: false,
+		},
+		{
+			name:          "given invalid port value when setup config then return error",
+			args:          []string{"-port=70000"},
+			parseError:    false,
+			validateError: true,
+		},
+		{
+			name:          "given non-existent cert file when setup config then return error",
+			args:          []string{"-port=8080", "-key=" + keyFile, "-cert=/non/existent/cert.pem"},
+			parseError:    false,
+			validateError: true,
+		},
+		{
+			name:          "given non-existent key file when setup config then return error",
+			args:          []string{"-port=8080", "-cert=" + certFile, "-key=/non/existent/key.pem"},
+			parseError:    false,
+			validateError: true,
+		},
+		{
+			name:          "given invalid flag format when setup config then return error",
+			args:          []string{"-extra"},
+			parseError:    true,
+			validateError: false, // No need to check Validate if ParseArgs fails
+		},
+		{
+			name:          "given port flag without value when setup config then return error",
+			args:          []string{"-port"},
+			parseError:    true,
+			validateError: false, // No need to check Validate if ParseArgs fails
+		},
+		{
+			name: "given empty key file and cert file when setup config then return valid config",
+			args: []string{"-port=8080"},
+			expected: signal.Config{
+				Port:     8080,
+				KeyFile:  "",
+				CertFile: "",
+			},
+			parseError:    false,
+			validateError: false,
+		},
+		{
+			name:          "given empty key file and non-empty cert file when setup config then return error",
+			args:          []string{"-port=8080", "-cert=" + certFile},
+			parseError:    false,
+			validateError: true,
+		},
+		{
+			name:          "given non-empty key file and empty cert file when setup config then return error",
+			args:          []string{"-port=8080", "-key=" + keyFile},
+			parseError:    false,
+			validateError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			originalArgs := os.Args
+			defer func() { os.Args = originalArgs }()
+
+			os.Args = append([]string{"cmd"}, tt.args...)
+
+			config, err := cmd.SetupConfig()
+
+			if tt.parseError {
+				if err == nil {
+					t.Errorf("SetupConfig() expected ParseArgs error, got nil")
+				}
+				return
+			}
+
+			if tt.validateError {
+				if err == nil {
+					t.Errorf("SetupConfig() expected Validate error, got nil")
+				}
+				return
+			}
+
+			if !config.IsSame(tt.expected) {
+				t.Errorf("%s: SetupConfig() = %v, expected %v", tt.name, config, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This pull request adds unit tests for the `cmd package`, specifically targeting the `ParseArgs` and `SetupConfig` functions. These tests are designed to cover various scenarios, including valid command-line arguments, missing or incorrect values, extra arguments, and error cases such as invalid flag formats and non-existent file paths. The goal is to ensure that the `cmd package` handles configuration inputs robustly and consistently.

#### Background

The addition of these tests is essential to maintain the reliability and stability of the `cmd package`. Configuration errors can lead to misconfigurations or crashes, so testing helps prevent these issues and ensures the codebase remains maintainable and trustworthy.

### Related Issues

This pull request addresses the issue: 
- #50 

### Changes Made
- Added unit tests for `cmd.ParseArgs`:
  - Tests for valid argument scenarios
  - Tests for cases with missing, incorrect, or extra arguments
  - Error handling for invalid flag formats and non-flag arguments
- Implemented tests for `cmd.SetupConfig`:
  - Scenarios with valid configurations and default values
  - Validation of configuration with non-existent `KeyFile` and `CertFile`
  - Use of helper functions to create temporary files for testing
- Ensured test isolation by restoring `os.Args` after each test

### Checklist
- [x] Tests have been added/updated or not required
- [x] didn't break anything

### Additional Context
- Temporary files are used in the tests to simulate valid and invalid file paths for `KeyFile` and `CertFile`. These files are cleaned up after the tests run.
- The `os.Args` values are restored after each test to ensure that subsequent tests are not affected.

### Reviewer Notes


